### PR TITLE
Update vim function names

### DIFF
--- a/plugin/exercism.vim
+++ b/plugin/exercism.vim
@@ -1,61 +1,61 @@
-autocmd VimEnter,BufRead,BufNewFile **/exercism/*/*/* call Exercism::Setup()
-function Exercism::Setup()
-  if Exercism::Track() == "csharp"
+autocmd VimEnter,BufRead,BufNewFile **/exercism/*/*/* call s:Setup()
+function s:Setup()
+  if s:Track() == "csharp"
     "" CSharp doesn't work yet, sorry
     return
   endif
-  nnoremap <leader>t :call Exercism::RunTests()<cr>
+  nnoremap <leader>t :call <sid>RunTests()<cr>
   nnoremap <leader>r :e README.md<cr>
-  nnoremap <leader><leader> :call Exercism::SwapFiles()<cr>
+  nnoremap <leader><leader> :call <sid>SwapFiles()<cr>
 
   "" Ocaml nicks the <leader>t binding for itself,
   "" so use <leader>m (for make) instead.
-  if Exercism::Track() == "ocaml"
-    nnoremap <leader>m :call Exercism::RunTests()<cr>
+  if s:Track() == "ocaml"
+    nnoremap <leader>m :call <sid>RunTests()<cr>
   endif
 endfunction
 
-function Exercism::StripNewline(str)
+function s:StripNewline(str)
   return a:str[0 : strlen(a:str) - 2]
 endfunction
 
-function Exercism::StripDotSlash(str)
+function s:StripDotSlash(str)
   return a:str[2 : strlen(a:str) - 1]
 endfunction
 
-function Exercism::Track()
+function s:Track()
   let track = system("pwd | awk -F'/' '{print $(NF-1)}'")
-  return Exercism::StripNewline(track)
+  return s:StripNewline(track)
 endfunction
 
-function Exercism::TestCommand()
-  let track = Exercism::Track()
-  if     track == "clojure"      | return "lein exec "             . Exercism::TestFile()
-  elseif track == "coffeescript" | return "jasmine-node --coffee " . Exercism::TestFile()
-  elseif track == "elixir"       | return "elixir "                . Exercism::TestFile()
+function s:TestCommand()
+  let track = s:Track()
+  if     track == "clojure"      | return "lein exec "             . s:TestFile()
+  elseif track == "coffeescript" | return "jasmine-node --coffee " . s:TestFile()
+  elseif track == "elixir"       | return "elixir "                . s:TestFile()
   elseif track == "go"           | return "go test"
-  elseif track == "haskell"      | return "runhaskell -Wall "      . Exercism::TestFile()
-  elseif track == "javascript"   | return "jasmine-node "          . Exercism::TestFile()
-  elseif track == "objective-c"  | return "objc "                  . Exercism::ObjectiveCExerciseName()
+  elseif track == "haskell"      | return "runhaskell -Wall "      . s:TestFile()
+  elseif track == "javascript"   | return "jasmine-node "          . s:TestFile()
+  elseif track == "objective-c"  | return "objc "                  . s:ObjectiveCExerciseName()
   elseif track == "ocaml"        | return "make"
-  elseif track == "perl5"        | return "prove "                 . Exercism::TestFile()
-  elseif track == "python"       | return "python "                . Exercism::TestFile()
-  elseif track == "ruby"         | return "ruby "                  . Exercism::TestFile()
+  elseif track == "perl5"        | return "prove "                 . s:TestFile()
+  elseif track == "python"       | return "python "                . s:TestFile()
+  elseif track == "ruby"         | return "ruby "                  . s:TestFile()
   elseif track == "scala"        | return "sbt test"
   endif
 endfunction
 
-function Exercism::ObjectiveCExerciseName()
+function s:ObjectiveCExerciseName()
   let name = system("find . -name \"*.h\" | xargs basename | awk -F'.' '{print $1}'")
-  return Exercism::StripNewline(name)
+  return s:StripNewline(name)
 endfunction
 
-function Exercism::RunTests()
-  execute("!" . Exercism::TestCommand())
+function s:RunTests()
+  execute("!" . s:TestCommand())
 endfunction
 
-function Exercism::TestFile()
-  let track = Exercism::Track()
+function s:TestFile()
+  let track = s:Track()
   if     track == "clojure"      | let pattern = "*_test.clj"
   elseif track == "coffeescript" | let pattern = "*test.spec.coffee"
   elseif track == "elixir"       | let pattern = "*_test.exs"
@@ -69,15 +69,15 @@ function Exercism::TestFile()
   elseif track == "ruby"         | let pattern = "*_test.rb"
   elseif track == "scala"
     let scala_test_file = system("find . -name *.scala | grep test | head -n 1")
-    return Exercism::StripDotSlash(Exercism::StripNewline(scala_test_file))
+    return s:StripDotSlash(s:StripNewline(scala_test_file))
   endif
 
   let test_file = system("find . -name \"" . pattern . "\" | xargs basename | head -n 1")
-  return Exercism::StripNewline(test_file)
+  return s:StripNewline(test_file)
 endfunction
 
-function Exercism::SourceFile()
-  let track = Exercism::Track()
+function s:SourceFile()
+  let track = s:Track()
   if     track == "clojure"      | let pattern = "*.clj"
   elseif track == "coffeescript" | let pattern = "*.coffee"
   elseif track == "elixir"       | let pattern = "*.exs"
@@ -91,14 +91,14 @@ function Exercism::SourceFile()
   elseif track == "ruby"         | let pattern = "*.rb"
   elseif track == "scala"
     let scala_source_file = system("find . -name *.scala | grep -v test | head -n 1")
-    return Exercism::StripDotSlash(Exercism::StripNewline(scala_source_file))
+    return s:StripDotSlash(s:StripNewline(scala_source_file))
   endif
-  let source_file = system("find . -name \"" . pattern . "\" | grep -v " . Exercism::TestFile() . " | xargs basename | head -n 1")
-  return Exercism::StripNewline(source_file)
+  let source_file = system("find . -name \"" . pattern . "\" | grep -v " . s:TestFile() . " | xargs basename | head -n 1")
+  return s:StripNewline(source_file)
 endfunction
 
-function Exercism::SwapFiles()
-  if expand("%") == Exercism::SourceFile() | exec ':e ' . Exercism::TestFile()
-  else                                     | exec ':e ' . Exercism::SourceFile()
+function s:SwapFiles()
+  if expand("%") == s:SourceFile() | exec ':e ' . s:TestFile()
+  else                             | exec ':e ' . s:SourceFile()
   endif
 endfunction


### PR DESCRIPTION
Since patch vim patch 7.4.260, E884 is given.

To conform with the latest function naming rules this
commit makes all functions script-local.
